### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: npm build and test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/olehermanse/utils/security/code-scanning/3](https://github.com/olehermanse/utils/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code, installs dependencies, builds, and runs tests, it does not need write access to the repository. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow (just below the `name:` key and before the `on:` key). This will ensure that all jobs in the workflow inherit these minimal permissions unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
